### PR TITLE
[codex] add wavefront debug summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added `recordWavefrontTelemetry(...)` and `snapshot.wavefront` summaries for
+    active ray counts, queue overflows, hit-buffer occupancy, termination
+    reasons, hit kinds, and bounce-depth distribution.
+  - Added `summarizeWavefrontTelemetry(...)` as a compact formatting helper for
+    wavefront diagnostics.
 
 - **Changed**
-  - (placeholder)
+  - The browser demo now lazy-loads the local debug bundle through the harbor
+    showcase feature loader so disabled sessions stay cheap by default.
 
 - **Fixed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ scene from the public `@plasius/gpu-shared` package surface, while
 - Records queue depth, dispatch timings, and estimated invocation counts.
 - Records DAG-ready lane depth and dependency-unlock activity when integrations
   supply those samples.
+- Records compact wavefront queue, hit-buffer, and termination summaries
+  without dumping raw GPU buffers.
 - Summarizes frame-budget pressure alongside dispatch activity.
 - Accepts optional host-supplied hardware hints such as memory capacity or core
   count when a native or privileged runtime can provide them.
@@ -54,6 +56,7 @@ import {
   gpuDebugQueueClasses,
   gpuPipelinePhases,
   gpuResourceCategories,
+  summarizeWavefrontTelemetry,
 } from "@plasius/gpu-debug";
 
 const debug = createGpuDebugSession({
@@ -135,7 +138,27 @@ debug.recordPipelinePhase({
   snapshotAgeMs: 0,
 });
 
-console.log(debug.getSnapshot());
+debug.recordWavefrontTelemetry({
+  owner: "wavefront",
+  queueClass: "render",
+  frameId: "frame-101",
+  bounceDepth: 0,
+  activeRayCount: 128,
+  queueCapacity: 256,
+  hitBufferCount: 92,
+  terminationReasons: [
+    { reason: "emissive", count: 10 },
+    { reason: "environment", count: 4 },
+  ],
+  hitKinds: [
+    { kind: "triangle", count: 78 },
+    { kind: "environment", count: 4 },
+  ],
+});
+
+const snapshot = debug.getSnapshot();
+console.log(snapshot);
+console.log(summarizeWavefrontTelemetry(snapshot.wavefront));
 releaseParticles();
 ```
 
@@ -154,6 +177,8 @@ Portable WebGPU does not currently guarantee authoritative access to:
 - queue-depth and frame-budget summaries,
 - DAG-ready lane and dependency-unlock summaries when integrations report them,
 - pipeline phase and snapshot-lag summaries when integrations report them,
+- wavefront queue, hit-buffer, termination, and bounce-depth summaries when
+  integrations report compact telemetry,
 - optional hardware hints provided by the host runtime.
 
 If a native shell, browser extension, or proprietary platform layer can provide
@@ -167,6 +192,7 @@ an inferred optimization aid rather than a full hardware profiler.
 - `gpuDebugQueueClasses`
 - `gpuPipelinePhases`
 - `gpuResourceCategories`
+- `summarizeWavefrontTelemetry(snapshot.wavefront)`
 
 The exported constants are the docs-first enum contract for integrations that
 need to validate or surface queue classes, pipeline phases, or tracked resource

--- a/demo/main.js
+++ b/demo/main.js
@@ -148,6 +148,9 @@ await mountHarborShowcase({
   title: "Debug Telemetry in a 3D Harbor",
   subtitle:
     "Family-coordinated moonlit harbor validation for queue, dispatch, and pipeline instrumentation, overlaid on the same living scene the metrics describe.",
+  __showcaseFeatureLoaders: {
+    debug: async () => import("../dist/index.js"),
+  },
   createState,
   updateState,
   describeState,

--- a/docs/adrs/adr-0006-wavefront-queue-and-hit-summaries.md
+++ b/docs/adrs/adr-0006-wavefront-queue-and-hit-summaries.md
@@ -1,0 +1,64 @@
+# ADR-0006: Wavefront Queue and Hit Summaries
+
+- Status: Accepted
+- Date: 2026-06-17
+- Version: 1.0
+
+## Context
+
+The wavefront path-tracing backlog needs renderer-facing diagnostics that answer
+practical questions quickly:
+
+- how many active rays are still alive per bounce,
+- whether queue overflow is occurring,
+- what kinds of hits are being produced,
+- why paths are terminating.
+
+`@plasius/gpu-debug` already handles allocations, queues, dispatches, DAG
+telemetry, frames, and simulation-to-visual phase timing. It still lacks a
+compact summary surface for wavefront-specific diagnostics.
+
+The package must stay honest about what it can observe. Dumping full GPU ray or
+hit buffers would be expensive, package-specific, and often unavailable in the
+target runtime. The new diagnostics therefore need to remain caller-reported
+summary samples instead of pretending the package can inspect raw GPU memory
+portably.
+
+## Decision
+
+`@plasius/gpu-debug` will add a caller-reported wavefront telemetry contract:
+
+- `recordWavefrontTelemetry(...)` records per-bounce summary samples
+- `snapshot.wavefront` aggregates active-ray counts, queue utilization,
+  overflow totals, hit-buffer counts, termination reasons, hit kinds, and
+  bounce-depth distribution
+- `summarizeWavefrontTelemetry(...)` formats that snapshot into compact
+  operator-facing lines
+
+The package will not collect or expose raw ray-buffer or hit-buffer payloads by
+default. Integrations remain responsible for producing compact summary samples.
+
+## Consequences
+
+- Positive: renderer packages gain one shared local-first diagnostic surface for
+  bounce-pipeline inspection.
+- Positive: debugging stays lightweight and safe for browser and worker
+  environments because only summary samples are retained.
+- Positive: termination and hit-kind summaries can be correlated with existing
+  queue and dispatch telemetry in one snapshot.
+- Neutral: integrations must explicitly report wavefront summaries; the package
+  still does not invent data that the runtime does not expose.
+
+## Alternatives Considered
+
+- Export raw GPU buffers through `@plasius/gpu-debug`:
+  rejected because it would be heavyweight, package-specific, and often
+  impossible in portable WebGPU environments.
+- Leave wavefront diagnostics entirely package-local:
+  rejected because it would fragment the debug contract across renderer and
+  diagnostics packages.
+
+## References
+
+- `Plasius-LTD/plasius-ltd-site#1042`
+- `Plasius-LTD/gpu-debug#13`

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -5,3 +5,4 @@
 - [ADR-0003: Caller-Tracked Allocation Accounting](./adr-0003-caller-tracked-allocation-accounting.md)
 - [ADR-0004: Local Debug Hooks and Analytics Routing](./adr-0004-local-debug-hooks-and-analytics-routing.md)
 - [ADR-0005: Simulation-to-Visual Phase Telemetry](./adr-0005-simulation-to-visual-phase-telemetry.md)
+- [ADR-0006: Wavefront Queue and Hit Summaries](./adr-0006-wavefront-queue-and-hit-summaries.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { createGpuDebugSession, estimateDispatchInvocations } from "./session.js";
+export {
+  createGpuDebugSession,
+  estimateDispatchInvocations,
+  summarizeWavefrontTelemetry,
+} from "./session.js";
 export {
   gpuDebugQueueClasses,
   gpuPipelinePhases,

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,6 +6,7 @@ import type {
   GpuDebugSession,
   GpuDebugSessionOptions,
   GpuDebugSnapshot,
+  GpuDebugWavefrontSnapshot,
   GpuDependencyUnlockSample,
   GpuDispatchSample,
   GpuFrameSample,
@@ -13,6 +14,9 @@ import type {
   GpuQueueSample,
   GpuReadyLaneSample,
   GpuResourceCategory,
+  GpuWavefrontHitKindSample,
+  GpuWavefrontTerminationSample,
+  GpuWavefrontTelemetrySample,
   TrackedGpuAllocation,
 } from "./types.js";
 import {
@@ -36,6 +40,7 @@ const DEFAULT_OPTIONS = Object.freeze({
   maxRetainedReadyLaneSamples: 240,
   maxRetainedDependencyUnlockSamples: 240,
   maxRetainedPipelinePhaseSamples: 240,
+  maxRetainedWavefrontSamples: 240,
   maxRetainedFrameSamples: 240,
   maxTrackedAllocations: 512,
 });
@@ -46,6 +51,7 @@ const LIMITATIONS = Object.freeze([
   "Hardware hints are optional caller-supplied metadata and may be platform-specific.",
   "Ready-lane and dependency-unlock diagnostics are caller-reported integration samples, not automatic WebGPU counters.",
   "Pipeline phase and snapshot-lag diagnostics are caller-reported integration samples, not automatic WebGPU counters.",
+  "Wavefront queue, hit-buffer, and termination diagnostics are caller-reported summaries rather than full GPU buffer dumps.",
 ]);
 
 interface NormalizedAllocation extends Omit<TrackedGpuAllocation, "signal"> {
@@ -76,6 +82,24 @@ interface NormalizedPipelinePhaseSample
   durationMs?: number;
   snapshotAgeFrames?: number;
   snapshotAgeMs?: number;
+}
+
+type NormalizedWavefrontHitKindSample = GpuWavefrontHitKindSample;
+
+type NormalizedWavefrontTerminationSample = GpuWavefrontTerminationSample;
+
+interface NormalizedWavefrontTelemetrySample
+  extends Omit<
+    GpuWavefrontTelemetrySample,
+    "signal" | "hitKinds" | "terminationReasons"
+  > {
+  hitKinds: readonly NormalizedWavefrontHitKindSample[];
+  terminationReasons: readonly NormalizedWavefrontTerminationSample[];
+  bounceDepth: number;
+  activeRayCount: number;
+  queueCapacity?: number;
+  overflowCount: number;
+  hitBufferCount?: number;
 }
 
 function clampCount(value: number | undefined, fallback: number): number {
@@ -337,6 +361,130 @@ function normalizePipelinePhaseSample(
   };
 }
 
+function normalizeWavefrontHitKinds(
+  entries: GpuWavefrontTelemetrySample["hitKinds"]
+): readonly NormalizedWavefrontHitKindSample[] {
+  if (entries === undefined) {
+    return Object.freeze([]);
+  }
+  if (!Array.isArray(entries)) {
+    throw new Error("wavefront.hitKinds must be an array when provided.");
+  }
+  return Object.freeze(
+    entries.map((entry, index) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error(`wavefront.hitKinds[${index}] must be an object.`);
+      }
+      return Object.freeze({
+        kind: assertIdentifier(`wavefront.hitKinds[${index}].kind`, entry.kind),
+        count:
+          readPositiveInteger(`wavefront.hitKinds[${index}].count`, entry.count) ??
+          1,
+      });
+    })
+  );
+}
+
+function normalizeWavefrontTerminationReasons(
+  entries: GpuWavefrontTelemetrySample["terminationReasons"]
+): readonly NormalizedWavefrontTerminationSample[] {
+  if (entries === undefined) {
+    return Object.freeze([]);
+  }
+  if (!Array.isArray(entries)) {
+    throw new Error(
+      "wavefront.terminationReasons must be an array when provided."
+    );
+  }
+  return Object.freeze(
+    entries.map((entry, index) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error(
+          `wavefront.terminationReasons[${index}] must be an object.`
+        );
+      }
+      return Object.freeze({
+        reason: assertIdentifier(
+          `wavefront.terminationReasons[${index}].reason`,
+          entry.reason
+        ),
+        count:
+          readPositiveInteger(
+            `wavefront.terminationReasons[${index}].count`,
+            entry.count
+          ) ?? 1,
+      });
+    })
+  );
+}
+
+function normalizeWavefrontTelemetrySample(
+  sample: GpuWavefrontTelemetrySample
+): NormalizedWavefrontTelemetrySample {
+  if (sample.signal !== undefined && !isAbortSignalLike(sample.signal)) {
+    throw new Error("wavefront.signal must be an AbortSignal when provided.");
+  }
+
+  const queueCapacity = readPositiveInteger(
+    "wavefront.queueCapacity",
+    sample.queueCapacity
+  );
+  const activeRayCount =
+    readNonNegativeNumber("wavefront.activeRayCount", sample.activeRayCount) ?? 0;
+  if (!Number.isInteger(activeRayCount)) {
+    throw new Error("wavefront.activeRayCount must be an integer greater than or equal to zero.");
+  }
+  if (queueCapacity !== undefined && activeRayCount > queueCapacity) {
+    throw new Error(
+      "wavefront.activeRayCount cannot exceed wavefront.queueCapacity."
+    );
+  }
+
+  const bounceDepth =
+    readNonNegativeNumber("wavefront.bounceDepth", sample.bounceDepth) ?? 0;
+  if (!Number.isInteger(bounceDepth)) {
+    throw new Error("wavefront.bounceDepth must be an integer greater than or equal to zero.");
+  }
+
+  const overflowCount =
+    readNonNegativeNumber("wavefront.overflowCount", sample.overflowCount) ?? 0;
+  if (!Number.isInteger(overflowCount)) {
+    throw new Error("wavefront.overflowCount must be an integer greater than or equal to zero.");
+  }
+
+  const hitBufferCount = readNonNegativeNumber(
+    "wavefront.hitBufferCount",
+    sample.hitBufferCount
+  );
+  if (hitBufferCount !== undefined && !Number.isInteger(hitBufferCount)) {
+    throw new Error(
+      "wavefront.hitBufferCount must be an integer greater than or equal to zero."
+    );
+  }
+
+  return {
+    owner: assertIdentifier("wavefront.owner", sample.owner),
+    queueClass: assertEnumValue(
+      "wavefront.queueClass",
+      sample.queueClass,
+      gpuDebugQueueClasses
+    ),
+    frameId:
+      sample.frameId === undefined
+        ? undefined
+        : assertIdentifier("wavefront.frameId", sample.frameId),
+    bounceDepth,
+    activeRayCount,
+    queueCapacity,
+    overflowCount,
+    hitBufferCount,
+    hitKinds: normalizeWavefrontHitKinds(sample.hitKinds),
+    terminationReasons: normalizeWavefrontTerminationReasons(
+      sample.terminationReasons
+    ),
+  };
+}
+
 export function estimateDispatchInvocations(sample: GpuDispatchSample): number {
   const normalized = normalizeDispatchSample(sample);
   return (
@@ -374,6 +522,10 @@ export function createGpuDebugSession(
       options.maxRetainedPipelinePhaseSamples,
       DEFAULT_OPTIONS.maxRetainedPipelinePhaseSamples
     ),
+    maxRetainedWavefrontSamples: clampCount(
+      options.maxRetainedWavefrontSamples,
+      DEFAULT_OPTIONS.maxRetainedWavefrontSamples
+    ),
     maxRetainedFrameSamples: clampCount(
       options.maxRetainedFrameSamples,
       DEFAULT_OPTIONS.maxRetainedFrameSamples
@@ -393,6 +545,7 @@ export function createGpuDebugSession(
   const dispatchSamples: NormalizedDispatchSample[] = [];
   const dependencyUnlockSamples: NormalizedDependencyUnlockSample[] = [];
   const pipelinePhaseSamples: NormalizedPipelinePhaseSample[] = [];
+  const wavefrontSamples: NormalizedWavefrontTelemetrySample[] = [];
   const frameSamples: NormalizedFrameSample[] = [];
   let peakTrackedBytes = 0;
 
@@ -721,6 +874,106 @@ export function createGpuDebugSession(
     };
   };
 
+  const buildWavefrontSnapshot = (): GpuDebugWavefrontSnapshot => {
+    const activeRayCounts = wavefrontSamples.map((sample) => sample.activeRayCount);
+    const hitBufferCounts = wavefrontSamples
+      .map((sample) => sample.hitBufferCount)
+      .filter((value): value is number => value !== undefined);
+
+    const byBounceDepth = new Map<
+      number,
+      {
+        bounceDepth: number;
+        sampleCount: number;
+        activeRayCounts: number[];
+        hitBufferCounts: number[];
+        totalOverflowCount: number;
+      }
+    >();
+    const byTerminationReason = new Map<string, number>();
+    const byHitKind = new Map<string, number>();
+
+    const peakQueueUtilizationRatio = wavefrontSamples.reduce<number | undefined>(
+      (peak, sample) => {
+        if (sample.queueCapacity === undefined) {
+          return peak;
+        }
+        const ratio = sample.activeRayCount / sample.queueCapacity;
+        return peak === undefined ? ratio : Math.max(peak, ratio);
+      },
+      undefined
+    );
+
+    let totalOverflowCount = 0;
+    let peakOverflowCount = 0;
+    let maxBounceDepth: number | undefined;
+
+    for (const sample of wavefrontSamples) {
+      totalOverflowCount += sample.overflowCount;
+      peakOverflowCount = Math.max(peakOverflowCount, sample.overflowCount);
+      maxBounceDepth =
+        maxBounceDepth === undefined
+          ? sample.bounceDepth
+          : Math.max(maxBounceDepth, sample.bounceDepth);
+
+      const bucket = byBounceDepth.get(sample.bounceDepth) ?? {
+        bounceDepth: sample.bounceDepth,
+        sampleCount: 0,
+        activeRayCounts: [],
+        hitBufferCounts: [],
+        totalOverflowCount: 0,
+      };
+      bucket.sampleCount += 1;
+      bucket.activeRayCounts.push(sample.activeRayCount);
+      if (sample.hitBufferCount !== undefined) {
+        bucket.hitBufferCounts.push(sample.hitBufferCount);
+      }
+      bucket.totalOverflowCount += sample.overflowCount;
+      byBounceDepth.set(sample.bounceDepth, bucket);
+
+      for (const reason of sample.terminationReasons) {
+        pushAggregate(byTerminationReason, reason.reason, reason.count);
+      }
+      for (const kind of sample.hitKinds) {
+        pushAggregate(byHitKind, kind.kind, kind.count);
+      }
+    }
+
+    return {
+      sampleCount: wavefrontSamples.length,
+      averageActiveRayCount: average(activeRayCounts) ?? 0,
+      peakActiveRayCount:
+        activeRayCounts.length > 0 ? Math.max(...activeRayCounts) : 0,
+      peakQueueUtilizationRatio,
+      maxBounceDepth,
+      totalOverflowCount,
+      peakOverflowCount,
+      averageHitBufferCount: average(hitBufferCounts),
+      peakHitBufferCount:
+        hitBufferCounts.length > 0 ? Math.max(...hitBufferCounts) : undefined,
+      byBounceDepth: [...byBounceDepth.values()]
+        .map((bucket) => ({
+          bounceDepth: bucket.bounceDepth,
+          sampleCount: bucket.sampleCount,
+          averageActiveRayCount: average(bucket.activeRayCounts) ?? 0,
+          peakActiveRayCount: Math.max(...bucket.activeRayCounts),
+          averageHitBufferCount: average(bucket.hitBufferCounts),
+          peakHitBufferCount:
+            bucket.hitBufferCounts.length > 0
+              ? Math.max(...bucket.hitBufferCounts)
+              : undefined,
+          totalOverflowCount: bucket.totalOverflowCount,
+        }))
+        .sort((left, right) => left.bounceDepth - right.bounceDepth),
+      byTerminationReason: [...byTerminationReason.entries()]
+        .map(([reason, count]) => ({ reason, count }))
+        .sort((left, right) => right.count - left.count),
+      byHitKind: [...byHitKind.entries()]
+        .map(([kind, count]) => ({ kind, count }))
+        .sort((left, right) => right.count - left.count),
+    };
+  };
+
   return {
     isEnabled() {
       return enabled;
@@ -810,6 +1063,15 @@ export function createGpuDebugSession(
       );
       return true;
     },
+    recordWavefrontTelemetry(sample) {
+      if (!enabled || sample.signal?.aborted === true) {
+        return false;
+      }
+
+      wavefrontSamples.push(normalizeWavefrontTelemetrySample(sample));
+      trimHistory(wavefrontSamples, settings.maxRetainedWavefrontSamples);
+      return true;
+    },
     recordFrame(sample) {
       if (!enabled || sample.signal?.aborted === true) {
         return false;
@@ -870,6 +1132,7 @@ export function createGpuDebugSession(
         },
         dag: buildDagSnapshot(),
         pipeline: buildPipelineSnapshot(),
+        wavefront: buildWavefrontSnapshot(),
         limitations: LIMITATIONS,
       };
 
@@ -883,8 +1146,54 @@ export function createGpuDebugSession(
       dispatchSamples.splice(0, dispatchSamples.length);
       dependencyUnlockSamples.splice(0, dependencyUnlockSamples.length);
       pipelinePhaseSamples.splice(0, pipelinePhaseSamples.length);
+      wavefrontSamples.splice(0, wavefrontSamples.length);
       frameSamples.splice(0, frameSamples.length);
       peakTrackedBytes = 0;
     },
   };
+}
+
+export function summarizeWavefrontTelemetry(
+  snapshot: GpuDebugWavefrontSnapshot | undefined
+): readonly string[] {
+  if (!snapshot || snapshot.sampleCount === 0) {
+    return Object.freeze(["Wavefront telemetry: no samples recorded."]);
+  }
+
+  const lines = [
+    `Wavefront telemetry: ${snapshot.sampleCount} samples, peak ${snapshot.peakActiveRayCount} active rays, overflow ${snapshot.totalOverflowCount}, max bounce ${snapshot.maxBounceDepth ?? 0}.`,
+  ];
+
+  if (snapshot.byTerminationReason.length > 0) {
+    lines.push(
+      `Termination reasons: ${snapshot.byTerminationReason
+        .slice(0, 3)
+        .map((entry) => `${entry.reason}=${entry.count}`)
+        .join(", ")}.`
+    );
+  } else {
+    lines.push("Termination reasons: none recorded.");
+  }
+
+  if (snapshot.byHitKind.length > 0) {
+    lines.push(
+      `Hit kinds: ${snapshot.byHitKind
+        .slice(0, 3)
+        .map((entry) => `${entry.kind}=${entry.count}`)
+        .join(", ")}.`
+    );
+  } else {
+    lines.push("Hit kinds: none recorded.");
+  }
+
+  lines.push(
+    `Bounce depth: ${snapshot.byBounceDepth
+      .map(
+        (entry) =>
+          `b${entry.bounceDepth} avg=${entry.averageActiveRayCount.toFixed(1)} peak=${entry.peakActiveRayCount}`
+      )
+      .join("; ")}.`
+  );
+
+  return Object.freeze(lines);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface GpuDebugSessionOptions {
   maxRetainedReadyLaneSamples?: number;
   maxRetainedDependencyUnlockSamples?: number;
   maxRetainedPipelinePhaseSamples?: number;
+  maxRetainedWavefrontSamples?: number;
   maxRetainedFrameSamples?: number;
   maxTrackedAllocations?: number;
 }
@@ -124,6 +125,30 @@ export interface GpuPipelinePhaseSample {
   snapshotFrameId?: string;
   snapshotAgeFrames?: number;
   snapshotAgeMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface GpuWavefrontHitKindSample {
+  kind: string;
+  count: number;
+}
+
+export interface GpuWavefrontTerminationSample {
+  reason: string;
+  count: number;
+}
+
+export interface GpuWavefrontTelemetrySample {
+  owner: string;
+  queueClass: GpuDebugQueueClass;
+  frameId?: string;
+  bounceDepth: number;
+  activeRayCount: number;
+  queueCapacity?: number;
+  overflowCount?: number;
+  hitBufferCount?: number;
+  hitKinds?: readonly GpuWavefrontHitKindSample[];
+  terminationReasons?: readonly GpuWavefrontTerminationSample[];
   signal?: AbortSignal;
 }
 
@@ -235,6 +260,35 @@ export interface GpuDebugPipelineSnapshot {
   }[];
 }
 
+export interface GpuDebugWavefrontSnapshot {
+  sampleCount: number;
+  averageActiveRayCount: number;
+  peakActiveRayCount: number;
+  peakQueueUtilizationRatio?: number;
+  maxBounceDepth?: number;
+  totalOverflowCount: number;
+  peakOverflowCount: number;
+  averageHitBufferCount?: number;
+  peakHitBufferCount?: number;
+  byBounceDepth: readonly {
+    bounceDepth: number;
+    sampleCount: number;
+    averageActiveRayCount: number;
+    peakActiveRayCount: number;
+    averageHitBufferCount?: number;
+    peakHitBufferCount?: number;
+    totalOverflowCount: number;
+  }[];
+  byTerminationReason: readonly {
+    reason: string;
+    count: number;
+  }[];
+  byHitKind: readonly {
+    kind: string;
+    count: number;
+  }[];
+}
+
 export interface GpuDebugSnapshot {
   enabled: boolean;
   adapter: Readonly<GpuDebugAdapterInfo>;
@@ -244,6 +298,7 @@ export interface GpuDebugSnapshot {
   frames: GpuDebugFrameSnapshot;
   dag: GpuDebugDagSnapshot;
   pipeline: GpuDebugPipelineSnapshot;
+  wavefront: GpuDebugWavefrontSnapshot;
   limitations: readonly string[];
 }
 
@@ -257,6 +312,7 @@ export interface GpuDebugSession {
   recordDispatch(sample: GpuDispatchSample): boolean;
   recordDependencyUnlock(sample: GpuDependencyUnlockSample): boolean;
   recordPipelinePhase(sample: GpuPipelinePhaseSample): boolean;
+  recordWavefrontTelemetry(sample: GpuWavefrontTelemetrySample): boolean;
   recordFrame(sample: GpuFrameSample): boolean;
   getSnapshot(): GpuDebugSnapshot;
   reset(): void;

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -8,6 +8,7 @@ import {
   gpuDebugQueueClasses,
   gpuPipelinePhases,
   gpuResourceCategories,
+  summarizeWavefrontTelemetry,
 } from "../src/index.js";
 
 describe("gpu debug session", () => {
@@ -219,6 +220,99 @@ describe("gpu debug session", () => {
       },
     ]);
     expect(snapshot.limitations[1]).toContain("core-count");
+  });
+
+  it("summarizes wavefront queue, hit, and termination telemetry", () => {
+    const session = createGpuDebugSession({
+      enabled: true,
+    });
+
+    session.recordWavefrontTelemetry({
+      owner: "wavefront",
+      queueClass: "render",
+      frameId: "frame-7",
+      bounceDepth: 0,
+      activeRayCount: 128,
+      queueCapacity: 256,
+      hitBufferCount: 96,
+      terminationReasons: [
+        { reason: "emissive", count: 12 },
+        { reason: "environment", count: 4 },
+      ],
+      hitKinds: [
+        { kind: "triangle", count: 80 },
+        { kind: "environment", count: 4 },
+      ],
+    });
+    session.recordWavefrontTelemetry({
+      owner: "wavefront",
+      queueClass: "render",
+      frameId: "frame-7",
+      bounceDepth: 1,
+      activeRayCount: 48,
+      queueCapacity: 64,
+      overflowCount: 3,
+      hitBufferCount: 44,
+      terminationReasons: [
+        { reason: "max-depth", count: 2 },
+        { reason: "environment", count: 6 },
+      ],
+      hitKinds: [
+        { kind: "triangle", count: 18 },
+        { kind: "emissive", count: 9 },
+      ],
+    });
+
+    const snapshot = session.getSnapshot();
+    expect(snapshot.wavefront.sampleCount).toBe(2);
+    expect(snapshot.wavefront.peakActiveRayCount).toBe(128);
+    expect(snapshot.wavefront.totalOverflowCount).toBe(3);
+    expect(snapshot.wavefront.maxBounceDepth).toBe(1);
+    expect(snapshot.wavefront.byTerminationReason).toEqual([
+      { reason: "emissive", count: 12 },
+      { reason: "environment", count: 10 },
+      { reason: "max-depth", count: 2 },
+    ]);
+    expect(snapshot.wavefront.byHitKind).toEqual([
+      { kind: "triangle", count: 98 },
+      { kind: "emissive", count: 9 },
+      { kind: "environment", count: 4 },
+    ]);
+    expect(snapshot.wavefront.byBounceDepth).toEqual([
+      {
+        bounceDepth: 0,
+        sampleCount: 1,
+        averageActiveRayCount: 128,
+        peakActiveRayCount: 128,
+        averageHitBufferCount: 96,
+        peakHitBufferCount: 96,
+        totalOverflowCount: 0,
+      },
+      {
+        bounceDepth: 1,
+        sampleCount: 1,
+        averageActiveRayCount: 48,
+        peakActiveRayCount: 48,
+        averageHitBufferCount: 44,
+        peakHitBufferCount: 44,
+        totalOverflowCount: 3,
+      },
+    ]);
+
+    expect(summarizeWavefrontTelemetry(snapshot.wavefront)).toEqual([
+      "Wavefront telemetry: 2 samples, peak 128 active rays, overflow 3, max bounce 1.",
+      "Termination reasons: emissive=12, environment=10, max-depth=2.",
+      "Hit kinds: triangle=98, emissive=9, environment=4.",
+      "Bounce depth: b0 avg=128.0 peak=128; b1 avg=48.0 peak=48.",
+    ]);
+  });
+
+  it("handles empty wavefront telemetry summaries", () => {
+    const session = createGpuDebugSession({ enabled: true });
+    expect(session.getSnapshot().wavefront.sampleCount).toBe(0);
+    expect(summarizeWavefrontTelemetry(session.getSnapshot().wavefront)).toEqual([
+      "Wavefront telemetry: no samples recorded.",
+    ]);
   });
 
   it("bounds retained histories and ignores aborted inputs", () => {


### PR DESCRIPTION
## What changed
- add `recordWavefrontTelemetry(...)` and `snapshot.wavefront` summaries for active rays, queue overflow, hit-buffer occupancy, hit kinds, termination reasons, and bounce depth
- add `summarizeWavefrontTelemetry(...)` for compact operator-facing formatting
- cover populated and empty wavefront summary behavior with regression tests
- document the new diagnostics contract in the README, changelog, and ADR index

## Why
The remaining wavefront path-tracing slice needs a shared debug surface that can explain bounce-pipeline state without pretending the package can dump raw GPU buffers portably.

## Validation
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm test`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run typecheck`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run lint`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run build`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run test:coverage`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run pack:check`
