### PR TITLE
[codex] prepare gpu-debug v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.2.1] - 2026-06-17
+
+- **Added**
   - Added `recordWavefrontTelemetry(...)` and `snapshot.wavefront` summaries for
     active ray counts, queue overflows, hit-buffer occupancy, termination
     reasons, hit kinds, and bounce-depth distribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-debug",
-  "version": "0.1.5",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-debug",
-      "version": "0.1.5",
+      "version": "0.2.1",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-debug",
-  "version": "0.1.5",
+  "version": "0.2.1",
   "description": "Opt-in GPU debug instrumentation for tracked memory, dispatch, queue, and frame-budget metrics in Plasius WebGPU runtimes.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## What changed
- bump `@plasius/gpu-debug` metadata from `0.1.5` to `0.2.1`
- move the current `Unreleased` notes into a real `0.2.1` changelog section

## Why
The repo's protected `main` policy rejects the direct version/changelog push that `cd.yml -- bump=minor` attempts. This release-prep PR lands the metadata through the required PR path so the publish workflow can be rerun with `bump=none`.

## Validation
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm test`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run typecheck`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run lint`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run build`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run pack:check`
