### PR TITLE
chore: prepare release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 - **Security**
   - (placeholder)
 
+## [0.2.2] - 2026-06-22
+
+- **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
 ## [0.2.1] - 2026-06-17
 
 - **Added**
@@ -182,3 +196,4 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 [0.1.3]: https://github.com/Plasius-LTD/gpu-debug/releases/tag/v0.1.3
 [0.1.4]: https://github.com/Plasius-LTD/gpu-debug/releases/tag/v0.1.4
 [0.1.5]: https://github.com/Plasius-LTD/gpu-debug/releases/tag/v0.1.5
+[0.2.2]: https://github.com/Plasius-LTD/gpu-debug/releases/tag/v0.2.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-debug",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-debug",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-debug",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Opt-in GPU debug instrumentation for tracked memory, dispatch, queue, and frame-budget metrics in Plasius WebGPU runtimes.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- prepare `v0.2.2` for publication from protected `main`
- update package metadata to `0.2.2`
- move the current `Unreleased` notes into `0.2.2`

The CD workflow will continue only after this release metadata is present on `main`.