### PR TITLE
ci: use GitHub App token for release prepare

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,7 @@ jobs:
     with:
       bump: ${{ inputs.bump }}
       preid: ${{ inputs.preid }}
+      release_prep_app_client_id: ${{ vars.RELEASE_PREP_APP_CLIENT_ID }}
     secrets: inherit
 
   publish:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -11,6 +11,10 @@ on:
         description: "Pre-release id (for example beta or rc). Leave blank for stable."
         required: false
         type: string
+      release_prep_app_client_id:
+        description: "GitHub App client ID used to generate the release-prep installation token."
+        required: true
+        type: string
       base_branch:
         description: "Protected branch that must receive release metadata before publishing."
         required: false
@@ -83,7 +87,7 @@ jobs:
         id: release_prep_app_token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_PREP_APP_CLIENT_ID }}
+          client-id: ${{ inputs.release_prep_app_client_id }}
           private-key: ${{ secrets.RELEASE_PREP_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: write


### PR DESCRIPTION
## Summary
- switch release metadata preparation from the temporary PAT path to a GitHub App installation token
- keep the release-prep PR flow so changelog and version updates still land on `main` before publish
- remove the `RELEASE_PREP_TOKEN` dependency from `release-prepare.yml`

## Validation
- workflow YAML parsed after update
- release workflow caller remains unchanged and still uses local `release-prepare.yml`